### PR TITLE
Enable systemd security features

### DIFF
--- a/systemd/system/syncthing-inotify@.service
+++ b/systemd/system/syncthing-inotify@.service
@@ -7,6 +7,10 @@ Requires=syncthing@.service
 [Service]
 User=%i
 ExecStart=/usr/bin/syncthing-inotify
+Restart=on-failure
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/user/syncthing-inotify.service
+++ b/systemd/user/syncthing-inotify.service
@@ -7,6 +7,9 @@ Requires=syncthing.service
 [Service]
 ExecStart=/usr/bin/syncthing-inotify
 Restart=on-failure
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
- PrivateTmp:    Let's jail syncthing-inotify into an own /tmp mount.
- ProtectHome:   The homedir of the user who runs syncthing-inotify is mounted as read only.
- ProtectSystem: /etc, /usr and /boot are mounted as read only.
- I also added forgotten Restart=on-failure to system unit
