### PR TITLE
systemd: ProtectHome was too strict

### DIFF
--- a/etc/linux-systemd/system/syncthing-inotify@.service
+++ b/etc/linux-systemd/system/syncthing-inotify@.service
@@ -10,7 +10,7 @@ ExecStart=/usr/bin/syncthing-inotify
 Restart=on-failure
 PrivateTmp=true
 ProtectSystem=full
-ProtectHome=true
+ProtectHome=read-only
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/linux-systemd/system/syncthing-inotify@.service
+++ b/etc/linux-systemd/system/syncthing-inotify@.service
@@ -8,7 +8,6 @@ Requires=syncthing@.service
 User=%i
 ExecStart=/usr/bin/syncthing-inotify
 Restart=on-failure
-PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
 

--- a/etc/linux-systemd/user/syncthing-inotify.service
+++ b/etc/linux-systemd/user/syncthing-inotify.service
@@ -7,7 +7,6 @@ Requires=syncthing.service
 [Service]
 ExecStart=/usr/bin/syncthing-inotify
 Restart=on-failure
-PrivateTmp=true
 ProtectSystem=full
 ProtectHome=read-only
 

--- a/etc/linux-systemd/user/syncthing-inotify.service
+++ b/etc/linux-systemd/user/syncthing-inotify.service
@@ -9,7 +9,7 @@ ExecStart=/usr/bin/syncthing-inotify
 Restart=on-failure
 PrivateTmp=true
 ProtectSystem=full
-ProtectHome=true
+ProtectHome=read-only
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
"ProtectHome=true" was too strict and caused problems when running under
the system instance. The problem does not appear when syncthing-inotify
is running under the user instance, thus I missed it in the first place.

"ProtectHome=read-only" fixes the problem.

Reported by: madalu mdl@imapmail.org
Reported on: https://aur.archlinux.org/packages/syncthing-inotify/
