### PR TITLE
systemd: Add logflags, refs #40

### DIFF
--- a/etc/linux-systemd/system/syncthing-inotify@.service
+++ b/etc/linux-systemd/system/syncthing-inotify@.service
@@ -6,7 +6,7 @@ Requires=syncthing@.service
 
 [Service]
 User=%i
-ExecStart=/usr/bin/syncthing-inotify
+ExecStart=/usr/bin/syncthing-inotify -logflags=0
 Restart=on-failure
 ProtectSystem=full
 ProtectHome=read-only

--- a/etc/linux-systemd/user/syncthing-inotify.service
+++ b/etc/linux-systemd/user/syncthing-inotify.service
@@ -5,7 +5,7 @@ After=network.target syncthing.service
 Requires=syncthing.service
 
 [Service]
-ExecStart=/usr/bin/syncthing-inotify
+ExecStart=/usr/bin/syncthing-inotify -logflags=0
 Restart=on-failure
 ProtectSystem=full
 ProtectHome=read-only


### PR DESCRIPTION
We don't need any timestamps in the journal. Systemd already handles
timestamps properly.
