### PR TITLE
systemd: Fix exit codes for systemd (fixes #39)

### DIFF
--- a/etc/linux-systemd/system/syncthing-inotify@.service
+++ b/etc/linux-systemd/system/syncthing-inotify@.service
@@ -7,6 +7,7 @@ Requires=syncthing@.service
 [Service]
 User=%i
 ExecStart=/usr/bin/syncthing-inotify -logflags=0
+SuccessExitStatus=2
 Restart=on-failure
 ProtectSystem=full
 ProtectHome=read-only

--- a/etc/linux-systemd/user/syncthing-inotify.service
+++ b/etc/linux-systemd/user/syncthing-inotify.service
@@ -6,6 +6,7 @@ Requires=syncthing.service
 
 [Service]
 ExecStart=/usr/bin/syncthing-inotify -logflags=0
+SuccessExitStatus=2
 Restart=on-failure
 ProtectSystem=full
 ProtectHome=read-only


### PR DESCRIPTION
The exit code 2 means a clean exit rather than an error. Let systemd
know this fact.
