### PR TITLE
Make aggregateChanges more testable.

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -731,7 +731,7 @@ func accumulateChanges(debounceTimeout time.Duration,
 				}
 
 				// Try to inform changes to syncthing and if succeeded, clean up
-				err = aggregateChanges(folder, folderPath, dirVsFiles, callback, paths)
+				err = callback(folder, aggregateChanges(folder, folderPath, dirVsFiles, paths))
 				if err == nil {
 					for _, path := range paths {
 						delete(inProgress, path)
@@ -764,10 +764,7 @@ func accumulateChanges(debounceTimeout time.Duration,
 // AggregateChanges optimises tracking in two ways:
 // - If there are more than `dirVsFiles` changes in a directory, we inform Syncthing to scan the entire directory
 // - Directories with parent directory changes are aggregated. If A/B has 3 changes and A/C has 8, A will have 11 changes and if this is bigger than dirVsFiles we will scan A.
-func aggregateChanges(folder string, folderPath string, dirVsFiles int, callback InformCallback, paths []string) error {
-	if len(paths) == 0 {
-		return errors.New("No changes to aggregate")
-	}
+func aggregateChanges(folder string, folderPath string, dirVsFiles int, paths []string) []string {
 	// Map paths to scores; if score == -1 the path is a filename
 	trackedPaths := make(map[string]int)
 	// Map of directories
@@ -849,7 +846,7 @@ func aggregateChanges(folder string, folderPath string, dirVsFiles int, callback
 			break
 		}
 	}
-	return callback(folder, scans)
+	return scans
 }
 
 // watchSTEvents reads events from Syncthing. For events of type ItemStarted and ItemFinished it puts

--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -731,7 +731,7 @@ func accumulateChanges(debounceTimeout time.Duration,
 				}
 
 				// Try to inform changes to syncthing and if succeeded, clean up
-				err = callback(folder, aggregateChanges(folder, folderPath, dirVsFiles, paths))
+				err = callback(folder, aggregateChanges(folderPath, dirVsFiles, paths))
 				if err == nil {
 					for _, path := range paths {
 						delete(inProgress, path)
@@ -764,7 +764,7 @@ func accumulateChanges(debounceTimeout time.Duration,
 // AggregateChanges optimises tracking in two ways:
 // - If there are more than `dirVsFiles` changes in a directory, we inform Syncthing to scan the entire directory
 // - Directories with parent directory changes are aggregated. If A/B has 3 changes and A/C has 8, A will have 11 changes and if this is bigger than dirVsFiles we will scan A.
-func aggregateChanges(folder string, folderPath string, dirVsFiles int, paths []string) []string {
+func aggregateChanges(folderPath string, dirVsFiles int, paths []string) []string {
 	// Map paths to scores; if score == -1 the path is a filename
 	trackedPaths := make(map[string]int)
 	// Map of directories

--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -860,7 +860,7 @@ func aggregateChanges(folderPath string, dirVsFiles int, paths []string, pathSta
 	// Decide if we should inform about particular path based on dirVsFiles
 	for i := range keys {
 		trackedPath := keys[i]
-		trackedPathScore, _ := trackedPaths[trackedPath]
+		trackedPathScore := trackedPaths[trackedPath]
 		if strings.HasPrefix(trackedPath, previousPath+pathSeparator) {
 			// Already informed parent directory change
 			continue

--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -761,12 +761,18 @@ func accumulateChanges(debounceTimeout time.Duration,
 	}
 }
 
+func cleanPaths(paths []string) {
+	for i := range paths {
+		paths[i] = filepath.Clean(paths[i])
+	}
+}
+
 func sortedUniqueAndCleanPaths(paths []string) []string {
+	cleanPaths(paths)
 	sort.Strings(paths)
 	var new_paths []string
 	previousPath := ""
-	for i := range paths {
-		path := filepath.Clean(paths[i])
+	for _, path := range paths {
 		if path == "." {
 			path = ""
 		}

--- a/syncwatcher_test.go
+++ b/syncwatcher_test.go
@@ -70,7 +70,7 @@ func TestDebouncedFileWatch(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != testFile {
-			t.Error("Invalid result for file change: "+repo, sub)
+			t.Errorf("Invalid result for file change: (%v) %#v", repo, sub)
 		}
 		testOK = true
 		return nil
@@ -99,7 +99,7 @@ func TestDebouncedDirectoryWatch(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != testFile {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK = true
 		return nil
@@ -131,7 +131,7 @@ func TestDebouncedParentDirectoryWatch(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != "a" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK = true
 		return nil
@@ -168,10 +168,10 @@ func TestDebouncedParentDirectoryWatch2(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 2 || sub[0] != "a" {
-			t.Error("Invalid result for directory change 1: "+repo, sub)
+			t.Errorf("Invalid result for directory change 1: (%v) %#v", repo, sub)
 		}
 		if repo != testRepo || sub[1] != "b" {
-			t.Error("Invalid result for directory change 2: "+repo, sub)
+			t.Errorf("Invalid result for directory change 2: (%v) %#v", repo, sub)
 		}
 		testOK = len(sub)
 		return nil
@@ -205,7 +205,7 @@ func TestDebouncedParentDirectoryWatch3(t *testing.T) {
 		}
 		for i, s := range sub {
 			if repo != testRepo || s != testFiles[i] {
-				t.Error("Invalid result for directory change " + strconv.Itoa(testOK) + ": " + repo + " " + s)
+				t.Errorf("Invalid result for directory change %t : (%v) %#v", testOK, repo, s)
 			}
 		}
 		testOK = len(sub)
@@ -242,10 +242,10 @@ func TestDebouncedParentDirectoryWatch4(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 2 || sub[0] != "a"+slash+"b" {
-			t.Error("Invalid result for directory change "+strconv.Itoa(testOK)+": "+repo, sub)
+			t.Errorf("Invalid result for directory change %t : (%v) %#v", testOK, repo, sub)
 		}
 		if repo != testRepo || sub[1] != "a"+slash+"e" {
-			t.Error("Invalid result for directory change "+strconv.Itoa(testOK)+": "+repo, sub)
+			t.Errorf("Invalid result for directory change %t : (%v) %#v", testOK, repo, sub)
 		}
 		testOK = len(sub)
 		return nil
@@ -280,7 +280,7 @@ func TestDebouncedParentDirectoryWatch5(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != "" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK = true
 		return nil
@@ -315,7 +315,7 @@ func TestDebouncedParentDirectoryWatch6(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != strings.TrimSuffix(testChangeDir, slash) {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK += 1
 		return nil
@@ -348,7 +348,7 @@ func TestDebouncedParentDirectoryRemovedWatch(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != "a" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK += 1
 		return nil
@@ -381,7 +381,7 @@ func TestSTEvents(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 0 {
-			t.Error("Invalid result for directory change: " + repo)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		testOK = false
 		return nil
@@ -418,7 +418,7 @@ func TestFilesAggregation(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 50 || sub[0] != "a/0" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		if testOK {
 			t.Error("Callback triggered multiple times")
@@ -456,7 +456,7 @@ func TestManyFilesAggregation(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != "" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		if testOK {
 			t.Error("Callback triggered multiple times")
@@ -494,7 +494,7 @@ func TestDeletesAggregation(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 50 || sub[0] != "a/0" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		if testOK {
 			t.Error("Callback triggered multiple times")
@@ -531,7 +531,7 @@ func TestManyDeletesAggregation(t *testing.T) {
 			return nil
 		}
 		if repo != testRepo || len(sub) != 1 || sub[0] != "" {
-			t.Error("Invalid result for directory change: "+repo, sub)
+			t.Errorf("Invalid result for directory change: (%v) %#v", repo, sub)
 		}
 		if testOK {
 			t.Error("Callback triggered multiple times")


### PR DESCRIPTION
~~Currently the last test (`checkAggregation(3, []string{"a/deleted1", "a/deleted2", "a/deleted3", "a/deleted4", "b/deleted1", "b/deleted2"}, []string{"a", "b/deleted1", "b/deleted2"})`
) fails. Unless I'm missing something I think that the deletes should have been aggregated into the parent dir (`a` in this case), but they aren't. Note that althought `TestDeletesAggregation` passes, in that case `sub` contains all 50 files, which I don't think is the intended result. Please correct me if I'm wrong.~~ I guess it's intentional that we notify syncthing about every deleted path.

Also, suggestions for more tests are welcome!
