### PR TITLE
Wait for frequently modified files to settle.

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -723,11 +723,11 @@ func accumulateChanges(debounceTimeout time.Duration,
 			if len(inProgress) < maxFiles {
 				for path, progress := range inProgress {
 					// Clean up invalid and expired paths
-					if path == "" || progress.time.Before(expiry) {
+					if path == "" || (!progress.fsEvent && progress.time.Before(expiry)) {
 						delete(inProgress, path)
 						continue
 					}
-					if progress.fsEvent {
+					if (progress.fsEvent && time.Now().Sub(progress.time) > currInterval) {
 						paths = append(paths, path)
 						Debug.Println("Informing about " + path)
 					} else {


### PR DESCRIPTION
Fixes #95.

Also, don't expire filesystem changes.
