### PR TITLE
print the folder id if installing the handler fails

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -432,7 +432,7 @@ func watchFolder(folder FolderConfiguration, stInput chan STEvent) {
 			Warning.Println(msg, err)
 			informError(msg)
 		} else {
-			Warning.Println("Failed to install inotify handlers", err)
+			Warning.Println("Failed to install inotify handler for " + folder.ID + ".", err)
 			informError("Failed to install inotify handler for " + folder.ID + ": " + err.Error())
 		}
 		return


### PR DESCRIPTION
the logging lacked the information which was the problematic folder id
even though the information is send to the syncthing process.
in combination with an upstream fix in notify ( https://github.com/Zillode/notify/pull/2 )
this will make debugging failures much easier as folder id and the failing node (i.e. path)
will be part of the error message.
