### PR TITLE
Make shouldIgnore's include handling compatible with syncthing

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -505,10 +505,10 @@ func shouldIgnore(ignorePaths []string, ignorePatterns []Pattern, path string) b
 			return true
 		}
 	}
-	for _, p1 := range ignorePatterns {
+	for iter, p1 := range ignorePatterns {
 		if p1.include && p1.match.MatchString(path) {
 			keep := false
-			for _, p2 := range ignorePatterns {
+			for _, p2 := range ignorePatterns[:iter] {
 				if !p2.include && p2.match.MatchString(path) {
 					Debug.Println("Keeping", path, "because", p2.match.String())
 					keep = true


### PR DESCRIPTION
Currently shouldIgnore returns false if any negated ignorePattern matches. In the [syncthing documentation on Ignoring Files](https://docs.syncthing.net/users/ignoring.html) it is stated, that including a path is only possible if it has not been previously ignored. Thus the second iteration is limited to ignorePatterns preceding the matching ignorePattern.
