### PR TITLE
adjust for notify ignore capability

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -440,8 +440,8 @@ func watchFolder(folder FolderConfiguration, stInput chan STEvent) {
 	ignorePatterns := getIgnorePatterns(folder.ID)
 	fsInput := make(chan string)
 	c := make(chan notify.EventInfo, maxFiles)
+	notify.SetIgnoreTest(ignoreTest(ignorePaths, ignorePatterns, folderPath))
 	if err := notify.Watch(filepath.Join(folderPath, "..."), c,
-		ignoreTest(ignorePaths, ignorePatterns,	folderPath),
 		notify.All); err != nil {
 		if strings.Contains(err.Error(), "too many open files") || strings.Contains(err.Error(), "no space left on device") {
 			msg := "Failed to install inotify handler for " + folder.ID + ". Please increase inotify limits, see http://bit.ly/1PxkdUC for more information."

--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -423,6 +423,16 @@ func getFolders() []FolderConfiguration {
 	return cfg.Folders
 }
 
+// returns a function that takes a path as string and returns a boolean,
+// indicating whether the path should be ignored
+func ignoreTest(ignorePaths []string, ignorePatterns []Pattern,
+	folderPath string) func(string) bool {
+	return func(path string) bool {
+		relPath := relativePath(path, folderPath)
+		return shouldIgnore(ignorePaths, ignorePatterns, relPath)
+	}
+}
+
 // watchFolder installs inotify watcher for a folder, launches
 // goroutine which receives changed items. It never exits.
 func watchFolder(folder FolderConfiguration, stInput chan STEvent) {
@@ -430,21 +440,14 @@ func watchFolder(folder FolderConfiguration, stInput chan STEvent) {
 	ignorePatterns := getIgnorePatterns(folder.ID)
 	fsInput := make(chan string)
 	c := make(chan notify.EventInfo, maxFiles)
-	if err := notify.Watch(filepath.Join(folderPath, "..."), c, notify.All); err != nil {
+	if err := notify.Watch(filepath.Join(folderPath, "..."), c,
+		ignoreTest(ignorePaths, ignorePatterns,	folderPath),
+		notify.All); err != nil {
 		if strings.Contains(err.Error(), "too many open files") || strings.Contains(err.Error(), "no space left on device") {
 			msg := "Failed to install inotify handler for " + folder.ID + ". Please increase inotify limits, see http://bit.ly/1PxkdUC for more information."
 			Warning.Println(msg, err)
 			informError(msg)
 			return
-		} else if strings.Contains(err.Error(), "error while traversing") {
-			re, _ := regexp.Compile("\"(/.+)\":")
-			errPath := re.FindStringSubmatch(err.Error())[1]
-			relErrPath := relativePath(errPath, folderPath)
-			if !shouldIgnore(ignorePaths, ignorePatterns, relErrPath) {
-				Warning.Println("Failed to install inotify handler for " + folder.ID + ".", err)
-				informError("Failed to install inotify handler for " + folder.ID + ": " + err.Error())
-				return
-			}
 		} else {
 			Warning.Println("Failed to install inotify handler for " + folder.ID + ".", err)
 			informError("Failed to install inotify handler for " + folder.ID + ": " + err.Error())


### PR DESCRIPTION
The reason for this PR is the same as in previous PR #101: Watching a folder should not be aborted if an error occurs on a ignored path. PR #101 incorrectly assumed that only syncthing-inotify aborts on such an error and notify does not. To resolve this the ability to ignore paths was introduced in PR Zillode/notify#3 on zillode/notify. This PR adapts the syncthing-inotify code to notify's new ignore capability.

Possible caveats:
- These PRs were only tested on linux and ext4 FS. All changes seem to be on a higher level than OS/FS, so it should work on other OS/FS too (but I am not certain).

I any case either these two PR must be accepted or the changes of PR #101 must be undone.
