### PR TITLE
Increase inotify limit: wrong systemd file mentioned.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ go build -ldflags "-w -X main.Version `git describe --abbrev=0 --tags`"
 
   Permanently fix `Too many open files` on most Linux distributions: ```sudo sh -c 'echo -e "fs.inotify.max_user_watches=204800\n" >> /etc/sysctl.conf'```
   
-  On Arch Linux, instead run: ```sudo sh -c 'echo -e "fs.inotify.max_user_watches=204800\n" >> /usr/lib/sysctl.d/50-default.conf'``` (see [this forum post](https://bbs.archlinux.org/viewtopic.php?id=193020))
+  On Arch Linux, instead run: ```sudo sh -c 'echo -e "fs.inotify.max_user_watches=204800\n" >> /etc/sysctl.d/90-override.conf'``` (see [this forum post](https://bbs.archlinux.org/viewtopic.php?id=193020))
 
   Fix `Too many open files` for Linux until next reboot: ```sudo sh -c 'echo 204800 > /proc/sys/fs/inotify/max_user_watches'``` (should be applied before launching syncthing-inotify)


### PR DESCRIPTION
/usr/lib/sysctl.d/50-default.conf says:

> To override settings in this file, create a local file in /etc
> (e.g. /etc/sysctl.d/90-override.conf), and put any assignments
> there.
