### PR TITLE
There is no network.target for user instances

### DIFF
--- a/etc/linux-systemd/user/syncthing-inotify.service
+++ b/etc/linux-systemd/user/syncthing-inotify.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Syncthing Inotify File Watcher
 Documentation=https://github.com/syncthing/syncthing-inotify/blob/master/README.md
-After=network.target syncthing.service
+After=syncthing.service
 Requires=syncthing.service
 
 [Service]


### PR DESCRIPTION
`network.target` is only available to system services and not user services so there is no point specifying a dependency.
