### PR TITLE
Fix notify version in godeps

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -14,7 +14,7 @@
 		},
 		{
 			"ImportPath": "github.com/zillode/notify",
-			"Rev": "2da5cc9881e8f16bab76b63129c7781898f97d16"
+			"Rev": "df33c1a773b462f936a149c36696c018c047eaa9"
 		}
 	]
 }


### PR DESCRIPTION
You need to update your version of https://github.com/zillode/notify in Godeps in order for build of v0.8.4-beta to work. Once merging this, please tag a second release of v0.8.4-beta so that I can create a devel version for Homebrew.
