### PR TITLE
Don't send syncthing the "subs" param when syncing entire folder

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -613,8 +613,10 @@ func informError(msg string) error {
 func informChange(folder string, subs []string) error {
 	data := url.Values{}
 	data.Set("folder", folder)
-	for _, sub := range subs {
-		data.Add("sub", sub)
+	if len(subs) != 1 || subs[0] != "" {
+		for _, sub := range subs {
+			data.Add("sub", sub)
+		}
 	}
 	if delayScan > 0 {
 		data.Set("next", strconv.Itoa(delayScan))


### PR DESCRIPTION
This should resolve syncthing/syncthing#3829

Starting with 0.14.14, syncthing has more strict checking of passed sub values, one of the contraints being not accepting an empty value. This can occur when `syncthing-inotify` aggregates a large volume of changes into a "complete folder sync" notification.