### PR TITLE
Do not exit if no folders are configured (Fixes #148)

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -310,9 +310,6 @@ func main() {
 
 	allFolders := getFolders()
 	folders := filterFolders(allFolders)
-	if len(folders) == 0 {
-		log.Fatalln("No folders to be watched, exiting...")
-	}
 	stChans := make(map[string]chan STEvent, len(folders))
 	for _, folder := range folders {
 		Debug.Println("Installing watch for " + folder.Label)


### PR DESCRIPTION
Wait for config update instead of exit in case there is no folder configured yet.