### PR TITLE
Adjust to new event API (fixes #154)

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -933,7 +933,7 @@ func watchSTEvents(stChans map[string]chan STEvent, folders []FolderConfiguratio
 			time.Sleep(configSyncTimeout)
 			continue
 		}
-		if events == nil {
+		if len(events) == 0 {
 			continue
 		}
 		for _, event := range events {


### PR DESCRIPTION
The API now returns an  empty slice instead of nil when there are no (new) events. I did not reproduce the issue, so I can't be 100% that this is the only issue, but I'd suggest 99%.