### PR TITLE
Use localhost if syncthing listens all addresses

### DIFF
--- a/syncwatcher.go
+++ b/syncwatcher.go
@@ -177,6 +177,8 @@ func init() {
 			target = "http://" + c.Target
 		}
 	}
+	target = strings.Replace(target, "://0.0.0.0:", "://127.0.0.1:", 1)
+	target = strings.Replace(target, "://[::]:", "://[::1]:", 1)
 
 	var logFile string
 	var verbosity int


### PR DESCRIPTION
If syncthing is configured to listen all interface (0.0.0.0 or [::]), syncthing-inotify fails to connect the API.
In such case, localhost should be used as the API target rather than 0.0.0.0 nor [::]

To reproduce, just change gui address in `~/.config/syncthing/config.xml` to 0.0.0.0
```
<gui enabled="true" tls="true" debugging="false">
        <address>0.0.0.0:8384</address>
...
```

Synthing-inotify will emit logs like,
```
Sep 29 00:01:43 myhost syncthing-inotify[1416]: [WARNING] Cannot connect to Syncthing: Get https://0.0.0.0:8384/rest/404: dial tcp 0.0.0.0:8384: getsockopt: connection refused
```

Attached pull request is just a mock of the fix. I am not a golang user. sorry.